### PR TITLE
Fix checking of name

### DIFF
--- a/src/main/java/tuthub/model/tutor/Name.java
+++ b/src/main/java/tuthub/model/tutor/Name.java
@@ -10,12 +10,16 @@ import static tuthub.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names can only contain letters, hyphens(-) or apostrophes(') between "
+                + "first name and last name, and must contain at least 1 word.\n"
+                + "E.g: Alex, Jack Alexander, Harry O'Neil, Smith-Jones.";
 
     /*
      * Name cannot be blank.
+     * Regex: 1 compulsory word, optional space, optional ' or -, optional words, no trailing spaces
+     * or spaces in front
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "^(?! )[A-Za-z]+((\\s)?((['|-])?([A-Za-z])+))*(?<! )$";
 
     public final String fullName;
 

--- a/src/test/java/tuthub/model/tutor/NameTest.java
+++ b/src/test/java/tuthub/model/tutor/NameTest.java
@@ -29,12 +29,22 @@ public class NameTest {
         assertFalse(Name.isValidName(" ")); // spaces only
         assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
         assertFalse(Name.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(Name.isValidName("peter12")); // contains numbers
+        assertFalse(Name.isValidName("jones@smith")); // contains symbols that are not allowed
+        assertFalse(Name.isValidName("jones smith@henry")); // contains symbols that are not allowed
+        assertFalse(Name.isValidName(" henry")); // spaces in front
+        assertFalse(Name.isValidName("henry ")); // spaces behind
+
+
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
-        assertTrue(Name.isValidName("12345")); // numbers only
-        assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
-        assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(Name.isValidName("David Roger Jackson Ray Jr")); // long names
+        assertTrue(Name.isValidName("Harry O'Neil")); // apostrophes
+        assertTrue(Name.isValidName("Smith-Jones")); // hyphens
+        assertTrue(Name.isValidName("Smith-Jones Henry")); // hyphens with more words
+        assertTrue(Name.isValidName("O'Neil Peter")); // apostrophes with more words
+
     }
 }

--- a/src/test/java/tuthub/model/tutor/TutorTest.java
+++ b/src/test/java/tuthub/model/tutor/TutorTest.java
@@ -42,11 +42,6 @@ public class TutorTest {
         // name differs in case, all other attributes same -> returns false
         Tutor editedBob = new TutorBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
         assertFalse(BOB.isSameTutor(editedBob));
-
-        // name has trailing spaces, all other attributes same -> returns false
-        String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
-        editedBob = new TutorBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSameTutor(editedBob));
     }
 
     @Test


### PR DESCRIPTION
Closes #141 

Update includes:
* Numbers not allowed within name
* Hyphens and apostrophes allowed within name
* Spaces in front and behind name not allowed

Test for trailing whitespace in `TutorTest#isSameTutor()` removed due to update in regex.